### PR TITLE
Change $USERNAME to $USER

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ similar operating systems.
 
 2. Edit your `~/.bashrc` (or `~/.bash_profile`) to add the following:
 
-        eval $(<location where you unpacked the zip>/weasel-pageant -r -a "/tmp/.weasel-pageant-$USERNAME")
+        eval $(<location where you unpacked the zip>/weasel-pageant -r -a "/tmp/.weasel-pageant-$USER")
 
     To explain:
 


### PR DESCRIPTION
Hello!
I think there should be ``$USER`` instead of  ``$USERNAME`` in the ``.bashrc``.
``$USERNAME`` doesn't seem to be defined in Bash.