### PR TITLE
Don't kill agent when tty disappears

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ of that window (when `-r` is given).
       -r, --reuse    Allow to reuse an existing -a SOCKET.
       -H, --helper   Path to the Win32 helper binary (default: /mnt/c/Program Files/weasel-pageant/helper.exe).
       -t TIME        Limit key lifetime in seconds (not supported by Pageant).
+      -b             Do not exit when tty closes (only use on Windows 10 version 1809 and newer).
 
 By default, the Win32 helper will be searched for in the same directory where `weasel-pageant`
 is stored. If you have placed it elsewhere, the `-H` flag can be used to set the location.
@@ -142,7 +143,8 @@ is stored. If you have placed it elsewhere, the `-H` flag can be used to set the
 * If you have an `SSH_AUTH_SOCK` variable set inside `screen`, `tmux` or similar,
   you exit the WSL console from which the `screen` was *initially started* and attach
   to the session from another window, the agent connection will not be usable. This is
-  due to WSL/Win32 interop limitations.
+  due to WSL/Win32 interop limitations. This can be circumvented on Windows 10 version
+  1809 and newer by adding the `-b` flag to the `weasel-pageant` command line.
 
 * There is a slight delay when exiting a WSL console before the window actually closes.
   This is due to a polling loop which works around a WSL incompatibility with Unix session

--- a/win32/win32.vcxproj
+++ b/win32/win32.vcxproj
@@ -23,7 +23,7 @@
     <ProjectGuid>{525D0B7F-C57F-49C4-9A90-E86D17F7F104}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>win32</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
     <ProjectName>win32</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />


### PR DESCRIPTION
As of version 1809, terminating the agent is no longer necessary when the spawning conhost exits. The Win32 helper process still needs to be terminated though.

Resolves issue #11.